### PR TITLE
Replace babel-eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,7 @@
     "prettier"
   ],
   "plugins": ["react", "import"],
-  "parser": "babel-eslint",
+  "parser": "@babel/eslint-parser",
   "rules": {
     "react/prefer-stateless-function": "off",
     "react/prop-types": "off",

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ ESLint rule configuration for Gatsby Sites. This rule set is designed to closely
 
 This config is designed to be used in conjunction with prettier for automatic code formatting. Conflicting rules have been disabled through `eslint-config-prettier`. See the "Use With Atom" section below for a suggestion on how to implement this config with prettier for automatic linting and formatting.
 
-`babel-eslint` is included to support new JavaScript features used in advanced Gatsby projects.
+`@babel/eslint-parser` is included to support new JavaScript features used in advanced Gatsby projects.
 
 ## Usage
 
@@ -38,10 +38,10 @@ content
 
 ## Plugins Used:
 
+- [@babel/eslint-plugin](https://github.com/babel/babel/tree/main/eslint/babel-eslint-plugin)
 - [eslint-config-standard](https://www.npmjs.com/package/eslint-config-standard)
 - [eslint-plugin-standard](https://www.npmjs.com/package/eslint-plugin-standard)
 - [eslint-plugin-react](https://www.npmjs.com/package/eslint-plugin-react)
-- [eslint-plugin-babel](https://github.com/babel/eslint-plugin-babel)
 - [eslint-config-standard-react](https://www.npmjs.com/package/eslint-config-standard-react)
 - [eslint-plugin-import](https://www.npmjs.com/package/eslint-plugin-import)
 - [eslint-plugin-node](https://www.npmjs.com/package/eslint-plugin-node)

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/brandonkal/eslint-config-gatsby-standard#readme",
   "dependencies": {
-    "babel-eslint": "^10.0.1",
+    "@babel/eslint-parser": "^7.16.5",
     "eslint-config-prettier": "^8.1.0",
     "eslint-config-standard": "^16.0.2",
     "eslint-config-standard-react": "^11.0.1",


### PR DESCRIPTION
babel-eslint is no longer supported and babel recommends replacing it with its eslint-parser instead.

Fixes #4 

**Note:** (from https://www.npmjs.com/package/@babel/eslint-parser)
ESLint's core rules do not support experimental syntax and may therefore not work as expected when using @babel/eslint-parser. Please use the companion [@babel/eslint-plugin](https://github.com/babel/babel/tree/main/eslint/babel-eslint-plugin) plugin for core rules that you have issues with.

**Note:**
I have not tested this and do not know how to test this since it's my first patch to an npm library. If you would like me to test this, please let me know a good way to do so.